### PR TITLE
Fix placeholder game page at /game route

### DIFF
--- a/docs/memories/development-logs/Task 21 - Fix Placeholder Game Page at Game Route.md
+++ b/docs/memories/development-logs/Task 21 - Fix Placeholder Game Page at Game Route.md
@@ -1,0 +1,88 @@
+# Task Development #21
+
+**Date**: 2025-11-14_13:21:36
+**Title**: Fix Placeholder Game Page at /game Route
+
+## Summary
+- Status: Completed
+- Estimated time: ~1 hour
+- Time spent: ~1 hour
+- Approach used: Created simple React component with i18n support to replace placeholder content
+- Subtasks completed: 21.1, 21.2, 21.3, 21.4, 21.5
+
+## Implementation
+
+### Subtask 21.1 - Analyze Current Implementation
+Reviewed the existing `src/pages/game.astro` file and found:
+- Simple centered layout with "Coming soon" placeholder
+- Prerendered static page
+- No i18n implementation
+- Clean slate for replacement content
+
+### Subtask 21.2 - Design UI
+Designed a simple, clean UI with:
+- Heading: "No Game in Progress"
+- Description: "Please start a new game to begin playing."
+- Call-to-action button: "Create New Game" linking to home page
+- Full internationalization support
+
+### Subtask 21.3 - Component Decision
+Initially planned to create inline Astro component, but ultimately created React components for proper i18n support:
+- `NoGamePrompt.tsx` - Main UI component
+- `NoGamePromptWithProvider.tsx` - Wrapper with I18nProvider
+
+### Subtask 21.4 - Implementation
+**Files Created:**
+1. `src/components/NoGamePrompt.tsx` - Main component using useTranslation
+2. `src/components/NoGamePromptWithProvider.tsx` - Provider wrapper
+
+**Files Modified:**
+1. `src/pages/game.astro` - Updated to use NoGamePromptWithProvider
+2. `public/locales/en/translation.json` - Added noGamePage translations
+3. `public/locales/es/translation.json` - Added Spanish translations
+4. `public/locales/pt-BR/translation.json` - Added Portuguese translations
+
+**Translation Keys Added:**
+```json
+"noGamePage": {
+  "title": "No Game in Progress",
+  "description": "Please start a new game to begin playing.",
+  "createButton": "Create New Game"
+}
+```
+
+**Technical Decisions:**
+- Used FALLBACK_LOCALE for prerendered page to avoid warnings
+- Created wrapper component following existing patterns (ScoreboardWithProvider, CategorySelectWithProvider)
+- Used shadcn/ui Button component as link for consistent styling
+- Maintained centered layout pattern from original placeholder
+
+### Subtask 21.5 - Verification
+- Dev server started successfully at http://localhost:4321/
+- Manual verification checklist prepared for user testing
+- All quality checks passed
+
+## Quality Assurance
+- ✅ Lint: Passed (Biome)
+- ✅ Typecheck: Passed (0 errors, 0 warnings)
+- ✅ Tests: All 307 tests passing
+- ✅ Build: Successful with no warnings
+- ✅ Coverage: Maintained 95.43% overall coverage
+
+## Observations
+- **Design Pattern**: Followed existing component wrapper pattern for i18n integration
+- **Simplicity**: Kept implementation minimal - only what was needed to solve the problem
+- **Internationalization**: Properly supported all 3 languages (en, es, pt-BR)
+- **User Experience**: Clear messaging with prominent call-to-action
+- **Code Quality**: All quality gates passed on first try after final fix
+
+## Technical Decisions Made
+1. **React vs Astro Component**: Chose React for proper i18n hook support
+2. **Wrapper Pattern**: Used provider wrapper pattern to match existing codebase conventions
+3. **Locale Handling**: Used FALLBACK_LOCALE for prerendered page to avoid header access warnings
+4. **Component Structure**: Created reusable NoGamePrompt component wrapped with provider
+
+## Possible Future Improvements
+- Could add visual enhancement with game-related icon or illustration
+- Could track analytics when users see this page (to measure how many users try to access /game directly)
+- Could add animation for smoother user experience

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -109,5 +109,10 @@
       "title": "No Players",
       "description": "No players found in this game session."
     }
+  },
+  "noGamePage": {
+    "title": "No Game in Progress",
+    "description": "Please start a new game to begin playing.",
+    "createButton": "Create New Game"
   }
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -109,5 +109,10 @@
       "title": "Sin Jugadores",
       "description": "No se encontraron jugadores en esta sesión de juego."
     }
+  },
+  "noGamePage": {
+    "title": "No Hay Juego en Curso",
+    "description": "Por favor, inicia un nuevo juego para comenzar a jugar.",
+    "createButton": "Crear Nuevo Juego"
   }
 }

--- a/public/locales/pt-BR/translation.json
+++ b/public/locales/pt-BR/translation.json
@@ -109,5 +109,10 @@
       "title": "Sem Jogadores",
       "description": "Nenhum jogador encontrado nesta sessão de jogo."
     }
+  },
+  "noGamePage": {
+    "title": "Nenhum Jogo em Andamento",
+    "description": "Por favor, inicie um novo jogo para começar a jogar.",
+    "createButton": "Criar Novo Jogo"
   }
 }

--- a/src/components/NoGamePrompt.tsx
+++ b/src/components/NoGamePrompt.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+
+export function NoGamePrompt() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex items-center justify-center min-h-screen p-4">
+      <div className="text-center space-y-4">
+        <h1 className="text-4xl font-bold">{t('noGamePage.title')}</h1>
+        <p className="text-muted-foreground text-lg">{t('noGamePage.description')}</p>
+        <div className="mt-6">
+          <Button asChild size="lg">
+            <a href="/">{t('noGamePage.createButton')}</a>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NoGamePromptWithProvider.tsx
+++ b/src/components/NoGamePromptWithProvider.tsx
@@ -1,0 +1,14 @@
+import { I18nProvider } from './I18nProvider';
+import { NoGamePrompt } from './NoGamePrompt';
+
+interface NoGamePromptWithProviderProps {
+  locale: string;
+}
+
+export function NoGamePromptWithProvider({ locale }: NoGamePromptWithProviderProps) {
+  return (
+    <I18nProvider locale={locale}>
+      <NoGamePrompt />
+    </I18nProvider>
+  );
+}

--- a/src/pages/game.astro
+++ b/src/pages/game.astro
@@ -1,14 +1,14 @@
 ---
+import { NoGamePromptWithProvider } from '../components/NoGamePromptWithProvider';
+import { FALLBACK_LOCALE } from '../i18n/locales';
 import Layout from '../layouts/Layout.astro';
 
 export const prerender = true;
+
+// Use fallback locale for prerendered page
+const locale = FALLBACK_LOCALE;
 ---
 
-<Layout title="Perfil - Game">
-	<div class="flex items-center justify-center min-h-screen p-4">
-		<div class="text-center">
-			<h1 class="text-4xl font-bold mb-4">Game Page</h1>
-			<p class="text-muted-foreground">Coming soon - This is where the game will be played</p>
-		</div>
-	</div>
+<Layout title="Perfil - No Game">
+	<NoGamePromptWithProvider locale={locale} client:only="react" />
 </Layout>


### PR DESCRIPTION
## Summary

- Replace confusing "Coming soon" placeholder on `/game` route with a clear user-friendly message
- Add internationalized "No Game in Progress" prompt with call-to-action button
- Provide proper navigation to game setup page for users who land on `/game` directly

## Changes

- **New Components:**
  - `NoGamePrompt.tsx` - Main UI component with i18n support
  - `NoGamePromptWithProvider.tsx` - Wrapper component with I18nProvider
  
- **Updated Files:**
  - `src/pages/game.astro` - Now uses NoGamePromptWithProvider instead of placeholder
  - Translation files (en, es, pt-BR) - Added `noGamePage` section with title, description, and button text

## Implementation Details

- Created reusable React component following existing patterns (similar to ScoreboardWithProvider, CategorySelectWithProvider)
- Used shadcn/ui Button component as link for consistent styling
- Properly internationalized in all 3 supported languages
- Used FALLBACK_LOCALE for prerendered page to avoid header access warnings
- Maintains centered layout pattern from original page

## Testing

- ✅ All 307 tests passing
- ✅ Lint checks passed
- ✅ Type checks passed (0 errors, 0 warnings)
- ✅ Build successful with no warnings
- ✅ Code coverage maintained at 95.43%

## Related

Closes task #21